### PR TITLE
Fix stack enter/leave for string vars

### DIFF
--- a/Sources/Mustache/MustacheContext.swift
+++ b/Sources/Mustache/MustacheContext.swift
@@ -74,7 +74,12 @@ struct MustacheContext {
             self.stack.append(data)
             return true
         case .string(let string):
-            return !["false", "0"].contains(string.lowercased())
+            if !["false", "0"].contains(string.lowercased()) {
+                self.stack.append(data)
+                return true
+            } else {
+                return false
+            }
         }
     }
 


### PR DESCRIPTION
Fixes an issue causing the variable stack to not propagate correctly for string variables (#15). 