### PR TITLE
Unwrap optional UnsafeMutablePointer<FILE>?

### DIFF
--- a/Sources/Mustache/MustacheContext.swift
+++ b/Sources/Mustache/MustacheContext.swift
@@ -98,6 +98,9 @@ struct MustacheContext {
                 guard let context = closure?.assumingMemoryBound(to: MustacheContext.self).pointee else {
                     return MUSTACH_ERROR_SYSTEM
                 }
+                guard let file = file else {
+                    return MUSTACH_ERROR_SYSTEM
+                }
                 fputs(context.put(name: name), file)
                 return MUSTACH_OK
             },


### PR DESCRIPTION
While trying to build vapor toolbox I encountered this error:

`error: value of optional type 'UnsafeMutablePointer<FILE>?' (aka 'Optional<UnsafeMutablePointer<_IO_FILE>>') must be unwrapped to a value of type 'UnsafeMutablePointer<FILE>' (aka 'UnsafeMutablePointer<_IO_FILE>')`

This fixes the issue.